### PR TITLE
Update fetch endpoint to get FBX files with metarig

### DIFF
--- a/examples/fetch_and_render_asset.py
+++ b/examples/fetch_and_render_asset.py
@@ -20,7 +20,6 @@ logging.getLogger('yellow-client').setLevel(logging.INFO)
 # auth = YellowAuthenticator.auth_with_token(token=TOKEN)
 
 # or authentiacate using token stored under OS env variable YELLOW_TOKEN
-# os.environ["YELLOW_TOKEN"] = "<token>"
 auth = YellowAuthenticator()
 
 sculpt = YellowSculpt(auth=auth)
@@ -41,8 +40,22 @@ for asset in assets_list:
 # get the last asset from the list
 uuid = assets_list[-1]["uuid"]
     
-# fetch the asset
-zip_path = sculpt.fetch_asset(uuid, "demo_output")
+# fetch the asset in fbx format
+sculpt.fetch_asset(
+    uuid=uuid, 
+    output_dir="output_to_fbx", 
+    file_format="fbx", 
+    rig_type="blender-basic-human-metarig"
+)
 
-# show the asset
+
+# fetch the asset in obj format
+zip_path = sculpt.fetch_asset(
+    uuid=uuid, 
+    output_dir="output_to_obj", 
+    file_format="obj", 
+    rig_type="no-rig"
+)
+
+# show the asset (only .obj is supported)
 sculpt.show_asset(zip_path)

--- a/examples/fetch_and_render_asset.py
+++ b/examples/fetch_and_render_asset.py
@@ -20,6 +20,7 @@ logging.getLogger('yellow-client').setLevel(logging.INFO)
 # auth = YellowAuthenticator.auth_with_token(token=TOKEN)
 
 # or authentiacate using token stored under OS env variable YELLOW_TOKEN
+# os.environ["YELLOW_TOKEN"] = "<token>"
 auth = YellowAuthenticator()
 
 sculpt = YellowSculpt(auth=auth)

--- a/examples/fetch_and_render_asset.py
+++ b/examples/fetch_and_render_asset.py
@@ -4,6 +4,8 @@ import logging
 
 from yellow.client.advanced.auth import YellowAuthenticator
 from yellow.client.advanced.sculpt import YellowSculpt
+from yellow.client.models.file_format_enum import FileFormatEnum
+from yellow.client.models.rig_type_enum import RigTypeEnum
 
 
 # configure logging
@@ -45,8 +47,8 @@ uuid = assets_list[-1]["uuid"]
 sculpt.fetch_asset(
     uuid=uuid, 
     output_dir="output_to_fbx", 
-    file_format="fbx", 
-    rig_type="blender-basic-human-metarig"
+    file_format=FileFormatEnum.FBX, 
+    rig_type=RigTypeEnum.BLENDER_BASIC_HUMAN_METARIG
 )
 
 
@@ -54,8 +56,8 @@ sculpt.fetch_asset(
 zip_path = sculpt.fetch_asset(
     uuid=uuid, 
     output_dir="output_to_obj", 
-    file_format="obj", 
-    rig_type="no-rig"
+    file_format=FileFormatEnum.OBJ, 
+    rig_type=RigTypeEnum.NO_RIG
 )
 
 # show the asset (only .obj is supported)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 vis = [
+    "chardet",
     "trimesh",
     "pyglet<2",
     "scipy",

--- a/yellow/client/advanced/sculpt.py
+++ b/yellow/client/advanced/sculpt.py
@@ -154,8 +154,8 @@ class YellowSculpt:
             self, 
             uuid: str, 
             output_dir: str, 
-            file_format: str = "obj",
-            rig_type: str = "no-rig",
+            file_format: str = FileFormatEnum.OBJ,
+            rig_type: str = RigTypeEnum.NO_RIG,
         )-> str:
         """Fetch/download an generated asset.
 

--- a/yellow/client/advanced/sculpt.py
+++ b/yellow/client/advanced/sculpt.py
@@ -171,19 +171,9 @@ class YellowSculpt:
         Returns:
             str: Output path
         """
-        try:
-            file_format = FileFormatEnum(file_format)
-        except ValueError:
-            raise ValueError(
-                f"Select file format from the list: {', '.join(enum.value for enum in FileFormatEnum)}"
-            )
 
-        try:
-            rig_type = RigTypeEnum(rig_type)
-        except ValueError:
-            raise ValueError(
-                f"Select rig type from the list: {', '.join(enum.value for enum in RigTypeEnum)}"
-            )
+        file_format = FileFormatEnum(file_format)
+        rig_type = RigTypeEnum(rig_type)
 
         logger.info(f"Checking status of UUID: {uuid}")
         response: Response = sculpt_characters_status_retrieve.sync_detailed(

--- a/yellow/client/advanced/sculpt.py
+++ b/yellow/client/advanced/sculpt.py
@@ -18,6 +18,8 @@ from yellow.client.api.sculpt import (
 )
 from yellow.client.models import CharacterSpecRequest
 from yellow.client.models.gender_enum import GenderEnum
+from yellow.client.models.file_format_enum import FileFormatEnum
+from yellow.client.models.rig_type_enum import RigTypeEnum
 from yellow.client.types import Response
 
 
@@ -148,12 +150,20 @@ class YellowSculpt:
         status_data = json.loads(response.content.decode())
         return status_data     
     
-    def fetch_asset(self, uuid: str, output_dir: str) -> str:
+    def fetch_asset(
+            self, 
+            uuid: str, 
+            output_dir: str, 
+            file_format: str = "obj",
+            rig_type: str = "no-rig",
+        )-> str:
         """Fetch/download an generated asset.
 
         Args:
             uuid (str): UUID of an asset
             output_dir (str): Directory to store an asset
+            file_format (str): File format of an asset
+            rig_type (str): Rig type applied to a mesh
 
         Raises:
             ValueError: Error recevied from the Yellow API during fetching an asset
@@ -161,6 +171,20 @@ class YellowSculpt:
         Returns:
             str: Output path
         """
+        try:
+            file_format = FileFormatEnum(file_format)
+        except ValueError:
+            raise ValueError(
+                f"Select file format from the list: {', '.join(enum.value for enum in FileFormatEnum)}"
+            )
+
+        try:
+            rig_type = RigTypeEnum(rig_type)
+        except ValueError:
+            raise ValueError(
+                f"Select rig type from the list: {', '.join(enum.value for enum in RigTypeEnum)}"
+            )
+
         logger.info(f"Checking status of UUID: {uuid}")
         response: Response = sculpt_characters_status_retrieve.sync_detailed(
             client=self.api_client, 
@@ -176,6 +200,8 @@ class YellowSculpt:
             response: Response = sculpt_characters_fetch_retrieve.sync_detailed(
                 client=self.api_client, 
                 generation_id=uuid,
+                file_format=file_format,
+                rig_type=rig_type,
             )
             self.auth.raise_satus_error(response)
 
@@ -229,6 +255,10 @@ class YellowSculpt:
                 shutil.unpack_archive(zip_path, zip_dst_dir)
                 logger.info(f"Zip file {zip_path} extracted to {zip_dst_dir}")
                 obj_paths.append(zip_dst_dir / model_name)
+        
+        if len(uuid_obj_paths := list(dst_dir.glob("*.obj"))) > 0:
+            for obj_path in uuid_obj_paths:
+                obj_paths.append(obj_path)
                 
         for obj_path in obj_paths:
             geometry = trimesh.load(obj_path)

--- a/yellow/client/api/sculpt/sculpt_characters_fetch_retrieve.py
+++ b/yellow/client/api/sculpt/sculpt_characters_fetch_retrieve.py
@@ -6,6 +6,8 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...types import UNSET, Response
+from ...models.file_format_enum import FileFormatEnum
+from ...models.rig_type_enum import RigTypeEnum
 
 
 def _get_kwargs(
@@ -57,8 +59,8 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     generation_id: str,
-    file_format: str = "obj",
-    rig_type: str = "no-rig",
+    file_format: str = FileFormatEnum.OBJ,
+    rig_type: str = RigTypeEnum.NO_RIG,
 ) -> Response[Any]:
     """Fetches the generated character.
 
@@ -92,8 +94,8 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     generation_id: str,
-    file_format: str = "obj",
-    rig_type: str = "no-rig",
+    file_format: str = FileFormatEnum.OBJ,
+    rig_type: str = RigTypeEnum.NO_RIG,
 ) -> Response[Any]:
     """Fetches the generated character.
 

--- a/yellow/client/api/sculpt/sculpt_characters_fetch_retrieve.py
+++ b/yellow/client/api/sculpt/sculpt_characters_fetch_retrieve.py
@@ -11,10 +11,14 @@ from ...types import UNSET, Response
 def _get_kwargs(
     *,
     generation_id: str,
+    file_format: str,
+    rig_type: str,
 ) -> Dict[str, Any]:
     params: Dict[str, Any] = {}
 
     params["generation_id"] = generation_id
+    params["file_format"] = file_format
+    params["rig_type"] = rig_type
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -53,11 +57,15 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     generation_id: str,
+    file_format: str = "obj",
+    rig_type: str = "no-rig",
 ) -> Response[Any]:
     """Fetches the generated character.
 
     Args:
         generation_id (str):
+        file_format (str):
+        rig_type (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -69,6 +77,8 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         generation_id=generation_id,
+        file_format=file_format,
+        rig_type=rig_type,
     )
 
     response = client.get_httpx_client().request(
@@ -82,11 +92,15 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     generation_id: str,
+    file_format: str = "obj",
+    rig_type: str = "no-rig",
 ) -> Response[Any]:
     """Fetches the generated character.
 
     Args:
         generation_id (str):
+        file_format (str):
+        rig_type (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -98,6 +112,8 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         generation_id=generation_id,
+        file_format=file_format,
+        rig_type=rig_type,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)

--- a/yellow/client/models/file_format_enum.py
+++ b/yellow/client/models/file_format_enum.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class FileFormatEnum(str, Enum):
+    OBJ = "obj"
+    FBX = "fbx"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/yellow/client/models/rig_type_enum.py
+++ b/yellow/client/models/rig_type_enum.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class RigTypeEnum(str, Enum):
+    NO_RIG = "no-rig"
+    BLENDER_BASIC_HUMAN_METARIG = "blender-basic-human-metarig"
+
+    def __str__(self) -> str:
+        return str(self.value)


### PR DESCRIPTION
This PR updates the fetch endpoint in the Python Client to reflect the latest changes in the API, enabling the download of FBX files with a metarig while maintaining OBJ files without a metarig as the default option. This update is important as our customers actively use the client, the endpoint only supported downloading OBJ files without a metarig. 

Manually tested using the fetching script: `examples/fetch_and_render_asset.py`
Tested in Colab: https://colab.research.google.com/drive/1uJK6WQt301LwF-mt1MVj1suPFXIwj9_h
